### PR TITLE
Fix issue with empty 'Executable path'

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient';
 
 export function activate(context: vscode.ExtensionContext) {
-	var path = vscode.workspace.getConfiguration('uiua').get<string>('executablePath') ?? 'uiua';
+	var path = vscode.workspace.getConfiguration('uiua').get<string>('executablePath') || 'uiua';
 	let serverOptions: ServerOptions = {
 		command: path,
 		args: ['lsp'],


### PR DESCRIPTION
Previously, when the `'Executable path'` parameter was left empty, the extension attempted to find the Uiua executable at an empty path:

![image](https://github.com/uiua-lang/uiua-vscode/assets/64745843/c431ede6-324d-4504-a804-e32fa58f5032)

Now the executable will be correctly searched for in the `PATH` environment variable.
