### PR TITLE
remove scheme:file to enable code formatting in notebook cells

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ export function activate(context: vscode.ExtensionContext) {
 		options: {}
 	};
 	let clientOptions: LanguageClientOptions = {
-		documentSelector: [{ scheme: 'file', language: 'uiua' }]
+		documentSelector: [{ language: 'uiua' }]
 	};
 
 	let client = new LanguageClient(


### PR DESCRIPTION
Hi there :) 

This PR removes the optional `scheme:'file'` property from the list of `documentSelector`s

This change enables jupyter notebook cells to use the "Format Document" feature of the LSP.
As someone mentioned on discord, users can then enable the built-in setting `"notebook.formatOnCellExecution": true` to get a more pad-like editing experience.

I can't tell if the `scheme:'file'` thing was needed for any other features to work? Everything seemed to function normally when it is removed.