### PR TITLE
prompt user to enable notebook.formatOnCellExecution

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,47 @@ export function activate(context: vscode.ExtensionContext) {
 	);
 	let disposable = client.start();
 
+    vscode.window.onDidChangeActiveNotebookEditor(async editor => {
+        // Undocumented: editor is defined when activating a notebook and undefined if switching away
+        if (editor?.notebook.notebookType === undefined) return;
+        // only prompt if the notebook is using the uiua language
+        if (editor?.notebook.metadata?.custom?.metadata?.language_info?.name?.toLowerCase()!=="uiua") return;
+            
+        const currentSetting = vscode.workspace.getConfiguration().get('notebook.formatOnCellExecution');
+        
+        if (!currentSetting) {
+            // Show a prompt to the user with a button to enable the setting
+            const selection = await vscode.window.showInformationMessage(
+                'The "notebook.formatOnCellExecution" setting is disabled, but it is highly recommended for Uiua. Would you like to enable it?',
+                'Workspace: Enable', 'User: Enable'
+            );
+            
+            let configuration_target:vscode.ConfigurationTarget;
+            let accepted_message:string;
+            
+            if (selection === 'User: Enable') {
+                configuration_target = vscode.ConfigurationTarget.Global;
+                accepted_message = 'The "notebook.formatOnCellExecution" setting has been enabled for all notebooks.'
+            }else if (selection === 'Workspace: Enable') {
+                configuration_target = vscode.ConfigurationTarget.Workspace;
+                accepted_message = 'the "notebook.formatOnCellExecution" setting has been enabled for all notebooks in this workspace.'
+            }else{
+                return; // User cancelled the prompt or the selection was invalid.
+            }
+
+            await vscode.workspace.getConfiguration().update('notebook.formatOnCellExecution', true, configuration_target);
+            let open_settings = await vscode.window.showInformationMessage(
+                accepted_message
+                +'\nTo disable it please open Settings and search for formatOnCellExecution',
+                "Open Settings"
+            )
+            
+            if (open_settings === "Open Settings") {
+                vscode.commands.executeCommand('workbench.action.openSettings', 'notebook.formatOnCellExecution');
+            }
+        }
+    });
+
 	context.subscriptions.push(disposable);
 }
 


### PR DESCRIPTION
This change prompts the user to enable the vscode built in setting `notebook.formatOnCellExecution` when switching focus to a notebook which is configured to use the `'uiua'` language
(see experimental kernel <https://github.com/thehappycheese/uiua_kernel>)

Given that the kernel is experimental, it may be too early to accept this PR

I am now also wondering:

- The extension should remember if the user refuses, so it can stop prompting
- Maybe there should also be a prompt to enable `editor.formatOnSave` when editing regular .ua files?
- It would be preferable to only enable this setting for uiua notebooks. Currently changing `notebook.formatOnCellExecution` or `editor.formatOnSave` wold apply to all notebooks. I figure this is fine, as long as it is set at the workspace level... but still it is undesirable behavior.
  - I tried to find a way to make this extension listen for notebook cell execution events, but I couldn't find one yet.