### PR TITLE
fix: provide `fileTypes` from the grammar

### DIFF
--- a/syntaxes/uiua.tmLanguage.json
+++ b/syntaxes/uiua.tmLanguage.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "Uiua",
+	"firstLineMatch": "^#!/.*\buiua\b",
 	"fileTypes": [
 		"ua"
 	],

--- a/syntaxes/uiua.tmLanguage.json
+++ b/syntaxes/uiua.tmLanguage.json
@@ -1,6 +1,9 @@
 {
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "Uiua",
+	"fileTypes": [
+		"ua"
+	],
 	"patterns": [
 		{
 			"include": "#comments"


### PR DESCRIPTION
This allows using the grammar with other tools supporting tmLanguage format. In particular, the grammar can be converted to `.sublime-syntax` format and used with tools such as [bat]. See [TextMate docs](https://macromates.com/manual/en/language_grammars#example_grammar).

[bat]: https://github.com/sharkdp/bat