### PR TITLE
Fix double clicking an identifier selecting glyphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
         "editor.inlayHints.enabled": "on",
         "editor.fontFamily": "Uiua386Color, Uiua386, DejaVu Sans Mono, monospace",
         "editor.suggestFontSize": 16,
-        "editor.unicodeHighlight.ambiguousCharacters": false
+        "editor.unicodeHighlight.ambiguousCharacters": false,
+        "editor.wordSeparators": "~@#$%^*()-=+[{]}\\|;:'\",.<>/?◠⌵+⌝’⍤∠˜◡⋯∩□⊓⊸⍩⌈⊛ℂ◇⊟◴∂♭⊙÷⍢↘.∵=η⍖⬚⌕⊢¤:⌊∧⊃⋅≥>⊕∘⊗∞∫⍚⊂▽⊣⧻≤<ₙ⦷≍↥∊↧◿×¯¬≠⌅⤚⟜∨⤸,⋕⊜π⊡◌ⁿ⚂⇡𝄐/⍥☇↯⇌⍏↻⁅≡\\⊏˙△±∿⍆√?⧈-⨬⊞↙τ⸮⍉⍣⧅°⍜◰⊚◫⤙"
       },
       "editor.semanticTokenColorCustomizations": {
         "rules": {

--- a/syntaxes/uiua.tmLanguage.json
+++ b/syntaxes/uiua.tmLanguage.json
@@ -61,7 +61,7 @@
 	"repository": {
 		"idents": {
 			"name": "variable.parameter.uiua",
-			"match": "\\b[a-zA-Z]+([₀₁₂₃₄₅₆₇₈₉]|__\\d+)*[!‼]*\\b"
+			"match": "\\b[a-zA-Z]+(₋?[₀₁₂₃₄₅₆₇₈₉]|__`?\\d+)*[!‼]*\\b"
 		},
 		"comments": {
 			"name": "comment.line.uiua",


### PR DESCRIPTION
This change defines every Uiua glyph as a word separator. This fixes an issue I have where double clicking an identifier to select it would also select nearby glyphs, which often results in unintentionally deleting some necessary logic when refactoring code. This change also excludes `!` and `&` from separators, because they are also often a part of an identifier and you would want to select them when double clicking an identifier.

As a bonus, when I was browsing the code, I noticed that the identifier definition in `uiua.tmLanguage.json` did not include negative subscripts, so I also added those.